### PR TITLE
Add Responsive Styling to Recaptcha

### DIFF
--- a/static/css/contact.css
+++ b/static/css/contact.css
@@ -110,6 +110,35 @@
     transform: scale(1.05);
 }
 
+.recaptcha-container {
+    display: flex;
+    justify-content: center;
+    transform: scale(0.85);
+    /* Default scaling */
+    transform-origin: center;
+}
+
+@media (max-width: 425px) {
+    .recaptcha-container {
+        transform: scale(0.75);
+        /* Scale down for smaller screens */
+    }
+}
+
+@media (max-width: 375px) {
+    .recaptcha-container {
+        transform: scale(0.65);
+        /* Further shrink for very small screens */
+    }
+}
+
+@media (max-width: 320px) {
+    .recaptcha-container {
+        transform: scale(0.55);
+        /* Final smallest size */
+    }
+}
+
 /* Responsive Adjustments */
 @media (max-width: 768px) {
     .contact-form {

--- a/templates/index.html
+++ b/templates/index.html
@@ -362,9 +362,11 @@
                 <label for="message">Message:</label>
                 <textarea id="message" name="message" placeholder="Write your message here..." rows="5" required></textarea>
             </div>
-            
+
             <!-- recaptcha -->
-            <div class="g-recaptcha" data-sitekey="6Lcr4ckqAAAAAMIthlCvwJEpAI-6SQewLLc5Jc8V"></div>
+            <div class="recaptcha-container">
+                <div class="g-recaptcha" data-sitekey="6Lcr4ckqAAAAAMIthlCvwJEpAI-6SQewLLc5Jc8V"></div>
+            </div>
 
             <div class="form-group agreement">
                 <p>By sending this message, you agree to our <a href="#" class="modal-trigger" data-modal="termsModal">Terms&nbsp;&&nbsp;Conditions</a> and <a href="#" class="modal-trigger" data-modal="privacyModal">Privacy&nbsp;Policy</a>.</p>


### PR DESCRIPTION
This pull request introduces changes to improve the responsiveness and layout of the reCAPTCHA component on the contact page. The changes include adjustments to CSS for better scaling on various screen sizes and updating the HTML structure to include a new container for the reCAPTCHA element.

Responsive design improvements:

* [`static/css/contact.css`](diffhunk://#diff-6fbf6946766b01aa74479eac253486d3c319bfe0de9c4e2b1802a073b50d81aaR113-R141): Added a new `.recaptcha-container` class with scaling properties and media queries to adjust the scale for different screen sizes.

HTML structure update:

* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R367-R369): Wrapped the reCAPTCHA element in a new `div` with the class `recaptcha-container` to apply the new styling.