### PR TITLE
Refine reCAPTCHA Styling

### DIFF
--- a/static/css/contact.css
+++ b/static/css/contact.css
@@ -113,33 +113,31 @@
 .recaptcha-container {
     display: flex;
     justify-content: center;
-    transform: scale(0.85);
-    /* Default scaling */
+    transform: scale(01.0);
     transform-origin: center;
 }
 
+
+/* Responsive Adjustments */
+
 @media (max-width: 425px) {
     .recaptcha-container {
-        transform: scale(0.75);
-        /* Scale down for smaller screens */
+        transform: scale(0.85);
     }
 }
 
 @media (max-width: 375px) {
     .recaptcha-container {
-        transform: scale(0.65);
-        /* Further shrink for very small screens */
+        transform: scale(0.75);
     }
 }
 
-@media (max-width: 320px) {
+@media (max-width: 315px) {
     .recaptcha-container {
-        transform: scale(0.55);
-        /* Final smallest size */
+        transform: scale(0.65);
     }
 }
 
-/* Responsive Adjustments */
 @media (max-width: 768px) {
     .contact-form {
         padding: 20px;


### PR DESCRIPTION
This pull request includes changes to the `static/css/contact.css` file to adjust the scaling of the reCAPTCHA container for different screen sizes. The changes aim to improve the responsiveness and visual consistency of the reCAPTCHA component.

Responsive adjustments:

* Changed the default scaling of the `.recaptcha-container` from `0.85` to `1.0` to ensure it appears at its intended size.
* Adjusted the scaling for screens with a maximum width of `425px` from `0.75` to `0.85` to provide better visibility on small screens.
* Adjusted the scaling for screens with a maximum width of `375px` from `0.65` to `0.75` to improve readability on very small screens.
* Changed the media query for screens with a maximum width from `320px` to `315px` and adjusted the scaling from `0.55` to `0.65` for the smallest screen sizes.