### PR TITLE
Add Honey pot protection to Contact form

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,9 +67,14 @@ def index():
         name = request.form.get("name")
         email = request.form.get("email")
         message = request.form.get("message")
+        honeypot = request.form.get("honeypot")
 
         if not name or not email or not message:
             return jsonify({"status": "error", "message": "Please fill out all required fields."})
+        
+        # Reject if the honeypot is filled (bot detected)
+        if honeypot:
+            return jsonify({"status": "error", "message": "Spam detected. Submission blocked."})
 
         # Verify reCAPTCHA response
         recaptcha_secret = os.getenv("RECAPTCHA_SECRET_KEY")  # Load secret key from .env

--- a/static/css/contact.css
+++ b/static/css/contact.css
@@ -117,6 +117,13 @@
     transform-origin: center;
 }
 
+/* Extra protection for Honeypot to remain unseen to users */
+#honeypot {
+    display: none !important;
+    visibility: hidden !important;
+    position: absolute !important;
+    left: -9999px !important;
+}
 
 /* Responsive Adjustments */
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -363,6 +363,12 @@
                 <textarea id="message" name="message" placeholder="Write your message here..." rows="5" required></textarea>
             </div>
 
+            <!-- Honeypot field -->
+            <div style="display: none;">
+                <label for="honeypot">Leave this field empty</label>
+                <input type="text" id="honeypot" name="honeypot">
+            </div>
+
             <!-- recaptcha -->
             <div class="recaptcha-container">
                 <div class="g-recaptcha" data-sitekey="6Lcr4ckqAAAAAMIthlCvwJEpAI-6SQewLLc5Jc8V"></div>


### PR DESCRIPTION
This pull request introduces a honeypot field as an additional spam prevention measure in the contact form. The main changes include updating the backend to handle the honeypot, adding the honeypot field to the HTML form, and ensuring it remains hidden from users using CSS.

### Spam Prevention Enhancements:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R70-R78): Added a honeypot field to the form data processing and included logic to reject submissions if the honeypot is filled, indicating a bot submission.
* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R366-R371): Added a hidden honeypot field to the contact form to trap bots.
* [`static/css/contact.css`](diffhunk://#diff-6fbf6946766b01aa74479eac253486d3c319bfe0de9c4e2b1802a073b50d81aaR120-R126): Ensured the honeypot field is invisible to users by applying CSS styles to hide it.