### PR TITLE
Change Policy links in contact form

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -418,7 +418,7 @@
             <input type="hidden" name="g-recaptcha-response" id="g-recaptcha-response">
 
             <div class="form-group agreement">
-                <p>By sending this message, you agree to our <a href="#" class="modal-trigger" data-modal="termsModal">Terms&nbsp;&&nbsp;Conditions</a> and <a href="#" class="modal-trigger" data-modal="privacyModal">Privacy&nbsp;Policy</a>.</p>
+                <p>By sending this message, you agree to our <a href="/terms">Terms&nbsp;&&nbsp;Conditions</a> and <a href="/privacy">Privacy&nbsp;Policy</a>.</p>
             </div>
 
             <div class="form-buttons">


### PR DESCRIPTION
This pull request includes a minor change to the `templates/index.html` file. The change updates the links for the Terms and Conditions and Privacy Policy to direct users to the correct pages.

* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L421-R421): Updated the links for Terms and Conditions and Privacy Policy to point to `/terms` and `/privacy` respectively.