### PR TITLE
Add google Authentication script for tokens

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,6 +125,10 @@ def privacy():
 def terms():
     return render_template("terms.html")
 
+@app.route("/oauth2callback")
+def oauth2callback():
+    return "OAuth2 callback successful!", 200
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/generate_token.py
+++ b/generate_token.py
@@ -1,0 +1,34 @@
+from google_auth_oauthlib.flow import InstalledAppFlow
+import pickle
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.send"]
+CREDENTIALS_FILE = "credentials.json"
+REDIRECT_URI = "https://jaycode.co.uk/oauth2callback"  # Must match your Google Cloud OAuth settings!
+
+def main():
+    flow = InstalledAppFlow.from_client_secrets_file(
+        CREDENTIALS_FILE, SCOPES, redirect_uri=REDIRECT_URI
+    )
+
+    # Generate the authorization URL
+    auth_url, _ = flow.authorization_url(prompt="consent", access_type="offline")
+
+    print("\n🔗 Open this link in your local browser and authorize the app:")
+    print(auth_url)
+
+    # Get the authorization code from the user
+    auth_code = input("\n📋 Paste the authorization code here: ").strip()
+
+    # Fetch token using the code
+    flow.fetch_token(code=auth_code)
+    creds = flow.credentials
+
+    # Save token
+    with open("token.pickle", "wb") as token_file:
+        pickle.dump(creds, token_file)
+
+    print("\n✅ Token generated and saved successfully!")
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
This pull request introduces OAuth2 authentication to the application by adding a new route and a script to generate tokens. The most important changes include adding an OAuth2 callback route in `app.py` and creating a new script, `generate_token.py`, to handle the OAuth2 token generation process.

OAuth2 Authentication:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R128-R131): Added a new route `/oauth2callback` to handle OAuth2 callbacks and return a success message.
* [`generate_token.py`](diffhunk://#diff-b83407398d2cf2436ddb54e6a78939ffc6e5cae59b461a457b5acf655e049133R1-R34): Created a new script to generate OAuth2 tokens using `google_auth_oauthlib.flow.InstalledAppFlow`. This script includes setting up OAuth2 credentials, generating an authorization URL, fetching the token, and saving it to a file.