### PR TITLE
Add code to retrieve gmail refresh token

### DIFF
--- a/extract_refresh_token.py
+++ b/extract_refresh_token.py
@@ -1,0 +1,10 @@
+import pickle
+
+# Load the token.pickle file
+with open("token.pickle", "rb") as token_file:
+    creds = pickle.load(token_file)
+
+# Extract and print the refresh token
+print("\n🔑 Your GMAIL_API_REFRESH_TOKEN:")
+print(creds.refresh_token)
+


### PR DESCRIPTION
This pull request includes a change to the `extract_refresh_token.py` file to add functionality for extracting and printing the refresh token from a pickle file.

* [`extract_refresh_token.py`](diffhunk://#diff-8e8f34804d75d913cf3b84c3a86856afbef98c6f60286af90d98cd6a64f80f02R1-R10): Added code to load the `token.pickle` file using the `pickle` module and print the refresh token.