### PR TITLE
Fix Modal close issue

### DIFF
--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -7,13 +7,7 @@ document.querySelectorAll('.modal-trigger').forEach(trigger => {
     });
 });
 
-// Close Modal
-document.querySelectorAll('.close').forEach(closeButton => {
-    closeButton.addEventListener('click', function () {
-        const modalId = this.getAttribute('data-modal'); // Get modal ID
-        document.getElementById(modalId).style.display = 'none'; // Hide modal
-    });
-});
+
 
 // Close Modal on Background Click
 window.addEventListener('click', function (e) {


### PR DESCRIPTION
This pull request includes a change to the `static/js/modals.js` file to improve the modal close functionality. The most important change is the removal of the event listeners for the close buttons, which simplifies the code and relies on background clicks to close the modals.

Codebase simplification:

* [`static/js/modals.js`](diffhunk://#diff-3932f594ad6e369e51a212b64866d9aee5c43f35cd7c585b51869e643a2962d8L10-R10): Removed the event listeners for the close buttons, which previously closed the modal when clicked. This change simplifies the code and relies on background clicks to close the modals.