### PR TITLE
Final Fix Modal close issue

### DIFF
--- a/static/js/contact.js
+++ b/static/js/contact.js
@@ -60,3 +60,10 @@ document.querySelector(".reset-button").addEventListener("click", function () {
         grecaptcha.reset(); // Reset reCAPTCHA
     }
 });
+
+document.addEventListener("DOMContentLoaded", function() {
+    const closeButton = document.querySelector("#flashMessageModal .close");
+    if (closeButton) {
+        closeButton.addEventListener("click", closeModal);
+    }
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -455,7 +455,7 @@
 
     <div id="flashMessageModal" class="modal">
         <div class="modal-content">
-            <span class="close" onclick="closeModal()">&times;</span>
+            <span class="close">&times;</span>
             <h2 id="flashMessageTitle"></h2>
             <p id="flashMessageText"></p>
         </div>


### PR DESCRIPTION
This pull request includes changes to improve the user interaction with modal dialogs on the contact page. The most important changes include adding an event listener to close the modal dialog when the close button is clicked and updating the HTML structure to remove inline JavaScript.

Improvements to modal dialog interaction:

* [`static/js/contact.js`](diffhunk://#diff-eb08093f2a3046191ac2a79cb512f91eaa25aba965eaac16b55c094d9cdfa987R63-R69): Added an event listener to the close button of the modal dialog to trigger the `closeModal` function when clicked. This ensures the modal can be closed properly using the close button.

HTML structure update:

* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L458-R458): Removed the inline `onclick` JavaScript from the close button inside the modal dialog and replaced it with a plain close button. This change promotes better separation of concerns and cleaner HTML.