### PR TITLE
Fix free review policy routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -164,6 +164,14 @@ def free_review():
     return render_template("free_review.html")
 
 
+@app.route("/free-review/terms")
+def free_review_terms():
+    return render_template("free-review-terms.html")
+
+@app.route("/free-review/privacy")
+def free_review_privacy():
+    return render_template("free-review-privacy.html")
+
 @app.route("/admin/dashboard")
 def admin_dashboard():
     if not session.get("admin_logged_in"):


### PR DESCRIPTION
This pull request includes new routes for the free review section in the `app.py` file. The most important changes are the addition of routes for the terms and privacy pages.

New routes added:

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R167-R174): Added a route for the free review terms page (`/free-review/terms`).
* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R167-R174): Added a route for the free review privacy page (`/free-review/privacy`).